### PR TITLE
If location contain a space, the github search will fail

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -23,7 +23,7 @@ SITBOT_EXTENSION = (function() {
         if (key == 's'){
           args[key] = value;
         } else {
-          url += encodeURIComponent(key + ':' + value + ' ');
+          url += encodeURIComponent(key + ':"' + value + '" ');
         }
       }
     })


### PR DESCRIPTION
If parameters' value contains a space, the search will fail. This put double quote arround  it to fix it.

For example, that happen when you set the location to Kuala Lumpur
